### PR TITLE
Add GitHub edit links back to management pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: OSG Management Area
 site_url: https://opensciencegrid.github.io/management/
-repo_url: null
+repo_url: https://github.com/opensciencegrid/management/
 theme:
   name: material
   custom_dir: osgthedocs


### PR DESCRIPTION
It's convenient for making quick PRs for minor tasks, such as updating
links on the AC page